### PR TITLE
Fix stats display order

### DIFF
--- a/CitraRNG/Pokemon.py
+++ b/CitraRNG/Pokemon.py
@@ -149,10 +149,10 @@ class Pokemon:
         return convertWord(self.data, 0xF6)
     
     def SpA(self):
-        return convertWord(self.data, 0xF8)
-    
-    def SpD(self):
         return convertWord(self.data, 0xFA)
     
-    def Spe(self):
+    def SpD(self):
         return convertWord(self.data, 0xFC)
+    
+    def Spe(self):
+        return convertWord(self.data, 0xF8)


### PR DESCRIPTION
Stats were displayed in the hp/atk/def/speed/spe atk/spe def order, while they should be (and are with this PR) displayed in the hp/atk/def/spe atk/spe def/speed order.

Before:
https://cdn.discordapp.com/attachments/405455828129415168/587000558376976404/Screenshot_20190608_210438.png

Now:
https://cdn.discordapp.com/attachments/405455828129415168/587011219106562098/Screenshot_20190608_221239.png