### PR TITLE
Handle SOS crashing, DexNav/Radar chain and step counter offsets

### DIFF
--- a/CitraRNG/main_window.py
+++ b/CitraRNG/main_window.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from PySide6.QtCore import QObject, QSettings, Signal, Slot
+from PySide6.QtCore import QSettings, Signal, Slot
 from PySide6.QtWidgets import QMainWindow, QMessageBox
 from ui_MainWindow import Ui_MainWindow
 from manager_oras import ManagerORAS
@@ -8,7 +8,6 @@ from manager_sm import ManagerSM
 from manager_usum import ManagerUSUM
 from manager_xy import ManagerXY
 from util import hexify
-from util import uint
 
 class MainWindow(QMainWindow, Ui_MainWindow):
     update = Signal()
@@ -130,7 +129,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.labelStatus.setText("Disconnected")
             self.comboBoxGameSelection.setEnabled(True)      
 
-    def toggleEnable(self, flag, index):
+    def toggleEnable(self, flag: bool, index: int):
         self.doubleSpinBoxDelay.setEnabled(flag)
 
         if index == 0 or index == 1:
@@ -272,9 +271,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     @Slot()
     def updateSOSRNG(self):
         if self.sosRNG:
-            #if self.manager.sosInitialSeed is None:
             stringSeed = self.lineEditSOSInitialSeed.text()
-            if stringSeed.__eq__(""):
+            if not stringSeed:
                 findSeed = True
                 ActualSosSeed = 0
             else:

--- a/CitraRNG/main_window.py
+++ b/CitraRNG/main_window.py
@@ -171,7 +171,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
                 return
 
-            difference, initialSeed, currentSeed, frameCount, save, tiny3, tiny2, tiny1, tiny0 = values
+            difference, initialSeed, currentSeed, frameCount, save, step, chain, tiny3, tiny2, tiny1, tiny0 = values
             
             # Check to see if frame changed at all
             if difference != 0:
@@ -179,6 +179,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 self.lineEditCurrentSeed6.setText(hexify(currentSeed))
                 self.lineEditFrame6.setText(str(frameCount))
                 self.lineEditSaveVariable.setText(hexify(save))
+                self.labelStepValue.setText(str(step))
+                self.labelChainValue.setText(str(chain))
                 self.lineEditTiny3.setText(hexify(tiny3))
                 self.lineEditTiny2.setText(hexify(tiny2))
                 self.lineEditTiny1.setText(hexify(tiny1))
@@ -362,6 +364,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if index == 0 or index == 1:
             self.tabWidget.widget(0).setEnabled(True)
             self.tabWidget.widget(1).setEnabled(False)
+            self.labelStepCount.setVisible(index == 1)
+            self.labelStepValue.setVisible(index == 1)
         else:
             self.tabWidget.widget(0).setEnabled(False)
             self.tabWidget.widget(1).setEnabled(True)

--- a/CitraRNG/main_window.py
+++ b/CitraRNG/main_window.py
@@ -296,7 +296,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             if difference != 0:
                 self.lineEditSOSInitialSeed.setText(hexify(initialSeed))
                 self.lineEditSOSCurrentSeed.setText(hexify(currentSeed))
-                self.lineEditSOSFrame.setText(str(frameCount))
+                self.lineEditSOSIndex.setText(str(frameCount))
                 self.lineEditSOSChainCount.setText(str(chainCount))
 
     def toggleSOSRNG(self):

--- a/CitraRNG/main_window.py
+++ b/CitraRNG/main_window.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from PySide6.QtCore import QSettings, Signal, Slot
+from PySide6.QtCore import QObject, QSettings, Signal, Slot
 from PySide6.QtWidgets import QMainWindow, QMessageBox
 from ui_MainWindow import Ui_MainWindow
 from manager_oras import ManagerORAS
@@ -8,6 +8,7 @@ from manager_sm import ManagerSM
 from manager_usum import ManagerUSUM
 from manager_xy import ManagerXY
 from util import hexify
+from util import uint
 
 class MainWindow(QMainWindow, Ui_MainWindow):
     update = Signal()
@@ -129,7 +130,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.labelStatus.setText("Disconnected")
             self.comboBoxGameSelection.setEnabled(True)      
 
-    def toggleEnable(self, flag: bool, index: int):
+    def toggleEnable(self, flag, index):
         self.doubleSpinBoxDelay.setEnabled(flag)
 
         if index == 0 or index == 1:
@@ -269,9 +270,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     @Slot()
     def updateSOSRNG(self):
         if self.sosRNG:
-            if self.manager.sosInitialSeed is None:
-                self.manager.readSOSInitialSeed()
-            
+            #if self.manager.sosInitialSeed is None:
+            stringSeed = self.lineEditSOSInitialSeed.text()
+            if stringSeed.__eq__(""):
+                findSeed = True
+                ActualSosSeed = 0
+            else:
+                findSeed = False
+                ActualSosSeed = int(stringSeed, 16)
+            self.manager.readSOSInitialSeed(ActualSosSeed, findSeed)
+
             values = self.manager.updateSOSFrameCount()
 
             # Handle infinite loop
@@ -284,7 +292,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                 return
             
             difference, initialSeed, currentSeed, frameCount, chainCount = values
-
             # Check to see if frame changed at all
             if difference != 0:
                 self.lineEditSOSInitialSeed.setText(hexify(initialSeed))

--- a/CitraRNG/manager6.py
+++ b/CitraRNG/manager6.py
@@ -24,6 +24,9 @@ class Manager6:
 
         self.saveVariable = None
 
+        self.stepCounter = None
+        self.chainLength = None
+
         self.getOffsets()
 
     def getOffsets(self):
@@ -105,7 +108,10 @@ class Manager6:
 
         save = readDWord(self.citra, self.saveVariable)
 
-        return difference, self.initialSeed, self.currentSeed, self.frameCount, save, tiny3, tiny2, tiny1, tiny0
+        step = readDWord(self.citra, self.stepCounter)
+        chain = readDWord(self.citra, self.chainLength)
+
+        return difference, self.initialSeed, self.currentSeed, self.frameCount, save, step, chain, tiny3, tiny2, tiny1, tiny0
 
     def getCurrentSeed(self):
         index = readDWord(self.citra, self.mtIndex)

--- a/CitraRNG/manager7.py
+++ b/CitraRNG/manager7.py
@@ -140,7 +140,7 @@ class Manager7:
             count += 1
 
             # Probably stuck in an infinite loop
-            if count > 20000:
+            if count > 100000:
                 return None            
             
         self.sosFrameCount += count

--- a/CitraRNG/manager7.py
+++ b/CitraRNG/manager7.py
@@ -115,8 +115,12 @@ class Manager7:
 
         return Pokemon(data)
 
-    def readSOSInitialSeed(self):
-        self.sosInitialSeed = readDWord(self.citra, self.sosSeedAddress)
+    def readSOSInitialSeed(self, ActualSOSSeed, checkSeed):
+        if (checkSeed == True):
+            self.sosInitialSeed = readDWord(self.citra, self.sosSeedAddress)
+        else:
+            self.sosInitialSeed = ActualSOSSeed
+
         self.sosSFMT = SFMT(self.sosInitialSeed)
         self.sosCurrentSeed = self.sosInitialSeed
         self.sosFrameCount = -1
@@ -136,7 +140,7 @@ class Manager7:
             count += 1
 
             # Probably stuck in an infinite loop
-            if count > 100000:
+            if count > 20000:
                 return None            
             
         self.sosFrameCount += count

--- a/CitraRNG/manager_oras.py
+++ b/CitraRNG/manager_oras.py
@@ -22,6 +22,9 @@ class ManagerORAS(Manager6):
 
         self.saveVariable = 0x8C71DB8
 
+        self.stepCounter = 0x8D3B508
+        self.chainLength = 0x8D3B57C
+
     def getWildOffset(self):
         pointer = readDWord(self.citra, 0x880313C) - 0x22C0
         if pointer < 0x8000000 or pointer > 0x8DF0000:

--- a/CitraRNG/manager_xy.py
+++ b/CitraRNG/manager_xy.py
@@ -22,8 +22,11 @@ class ManagerXY(Manager6):
 
         self.saveVariable = 0x8C6A6A4
 
+        self.stepCounter = 0
+        self.chainLength = 0x8D1B2B8
+
     def getWildOffset(self):
-        pointer = readDWord(self.citra, 0x880313c) - 0xA1C
+        pointer = readDWord(self.citra, 0x880313c)
         if pointer < 0x8000000 or pointer > 0x8DF0000:
             return 0x8805614
         else:

--- a/CitraRNG/ui_MainWindow.py
+++ b/CitraRNG/ui_MainWindow.py
@@ -229,6 +229,21 @@ class Ui_MainWindow(object):
 
         self.gridLayout_11.addWidget(self.lineEditSaveVariable, 4, 2, 1, 2)
 
+        self.labelStepCount = QLabel(self.groupBoxMainRNG6)
+        self.labelStepCount.setObjectName(u"labelStepCount")
+        self.gridLayout_11.addWidget(self.labelStepCount, 2, 2, 2, 2)
+        self.labelStepCount.setVisible(False)
+        self.labelStepValue = QLabel(self.groupBoxMainRNG6)
+        self.labelStepValue.setObjectName(u"labelStepValue")
+        self.gridLayout_11.addWidget(self.labelStepValue, 2, 4, 2, 3)
+        self.labelStepValue.setVisible(False)
+
+        self.labelChainLength = QLabel(self.groupBoxMainRNG6)
+        self.labelChainLength.setObjectName(u"labelChainLength")
+        self.gridLayout_11.addWidget(self.labelChainLength, 2, 0, 2, 2)
+        self.labelChainValue = QLabel(self.groupBoxMainRNG6)
+        self.labelChainValue.setObjectName(u"labelChainValue")
+        self.gridLayout_11.addWidget(self.labelChainValue, 2, 1, 2, 3)
 
         self.gridLayout_13.addWidget(self.groupBoxMainRNG6, 0, 1, 2, 1)
 
@@ -644,6 +659,10 @@ class Ui_MainWindow(object):
         self.labelMainFrame6.setText(QCoreApplication.translate("MainWindow", u"Frame:", None))
         self.pushButtonMainUpdate6.setText(QCoreApplication.translate("MainWindow", u"Update", None))
         self.labelSaveVariable.setText(QCoreApplication.translate("MainWindow", u"Save Variable:", None))
+        self.labelStepCount.setText(QCoreApplication.translate("MainWindow", u"Step Counter:", None))
+        self.labelStepValue.setText(QCoreApplication.translate("MainWindow", u"0", None))
+        self.labelChainLength.setText(QCoreApplication.translate("MainWindow", u"Chain Length:", None))
+        self.labelChainValue.setText(QCoreApplication.translate("MainWindow", u"0", None))
         self.tabWidgetGen6.setTabText(self.tabWidgetGen6.indexOf(self.tabMain6), QCoreApplication.translate("MainWindow", u"Main", None))
         self.groupBoxEggRNG6.setTitle(QCoreApplication.translate("MainWindow", u"Egg RNG", None))
         self.labelEggReady6.setText(QCoreApplication.translate("MainWindow", u"Egg Ready:", None))

--- a/CitraRNG/ui_MainWindow.py
+++ b/CitraRNG/ui_MainWindow.py
@@ -566,17 +566,17 @@ class Ui_MainWindow(object):
 
         self.gridLayout_5.addWidget(self.lineEditSOSCurrentSeed, 2, 1, 1, 1)
 
-        self.labelSOSFrame = QLabel(self.groupBoxSOS)
-        self.labelSOSFrame.setObjectName(u"labelSOSFrame")
+        self.labelSOSIndex = QLabel(self.groupBoxSOS)
+        self.labelSOSIndex.setObjectName(u"labelSOSIndex")
 
-        self.gridLayout_5.addWidget(self.labelSOSFrame, 3, 0, 1, 1)
+        self.gridLayout_5.addWidget(self.labelSOSIndex, 3, 0, 1, 1)
 
-        self.lineEditSOSFrame = QLineEdit(self.groupBoxSOS)
-        self.lineEditSOSFrame.setObjectName(u"lineEditSOSFrame")
-        self.lineEditSOSFrame.setMaxLength(8)
-        self.lineEditSOSFrame.setReadOnly(True)
+        self.lineEditSOSIndex = QLineEdit(self.groupBoxSOS)
+        self.lineEditSOSIndex.setObjectName(u"lineEditSOSIndex")
+        self.lineEditSOSIndex.setMaxLength(8)
+        self.lineEditSOSIndex.setReadOnly(True)
 
-        self.gridLayout_5.addWidget(self.lineEditSOSFrame, 3, 1, 1, 1)
+        self.gridLayout_5.addWidget(self.lineEditSOSIndex, 3, 1, 1, 1)
 
         self.labelSOSChainCount = QLabel(self.groupBoxSOS)
         self.labelSOSChainCount.setObjectName(u"labelSOSChainCount")
@@ -689,7 +689,7 @@ class Ui_MainWindow(object):
         self.pushButtonSOSReset.setText(QCoreApplication.translate("MainWindow", u"Reset", None))
         self.labelSOSInitialSeed.setText(QCoreApplication.translate("MainWindow", u"Initial Seed:", None))
         self.labelSOSCurrentSeed.setText(QCoreApplication.translate("MainWindow", u"Current Seed:", None))
-        self.labelSOSFrame.setText(QCoreApplication.translate("MainWindow", u"Frame:", None))
+        self.labelSOSIndex.setText(QCoreApplication.translate("MainWindow", u"Index:", None))
         self.labelSOSChainCount.setText(QCoreApplication.translate("MainWindow", u"Chain Count:", None))
         self.tabWidgetGen7.setTabText(self.tabWidgetGen7.indexOf(self.tabSOS), QCoreApplication.translate("MainWindow", u"SOS", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabGen7), QCoreApplication.translate("MainWindow", u"Gen 7", None))

--- a/CitraRNG/ui_MainWindow.py
+++ b/CitraRNG/ui_MainWindow.py
@@ -550,7 +550,7 @@ class Ui_MainWindow(object):
         self.lineEditSOSInitialSeed = QLineEdit(self.groupBoxSOS)
         self.lineEditSOSInitialSeed.setObjectName(u"lineEditSOSInitialSeed")
         self.lineEditSOSInitialSeed.setMaxLength(8)
-        self.lineEditSOSInitialSeed.setReadOnly(True)
+        self.lineEditSOSInitialSeed.setReadOnly(False)
 
         self.gridLayout_5.addWidget(self.lineEditSOSInitialSeed, 1, 1, 1, 1)
 


### PR DESCRIPTION
**Gen 6:** The chain length and step counter offsets for Radar/DexNav, are pretty useful, but their current position is annoying and they block the user from copying nearby fields (Current Seed, Frame).

**Gen 7:** When trying to read the SOS initial seed at the first turn of the battle, more than half of the time, the script returns the infinite loop message. This happens because the seed value is being read slightly wrong (usually off by ±1/2), something happening with Pcalc as well.
The workaround I thought for this, is to allow the user edit the SOS initial seed manually by trying close seeds until the script confirms that the edited value is the correct one.
This is also necessary for abusing the Citra save states, because immediately after the first turn, and every 624 advances (reasonable since SFMT), the Initial Seed value is being replaced by the Current seed value in memory so reloading a save state will result in the infinite loop message again.
In general: If the SOS Seed field is empty, the script will try read from memory, otherwise it will try the existing value.
